### PR TITLE
Edit profile page and redirect on login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  helper_method :current_user
+  helper_method :current_user, :edit_profile_page?
 
   def require_user
     redirect_to sign_in_path unless current_user
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
 
   def reject_user
     redirect_to reminders_path if current_user
+  end
+
+  def edit_profile_page?
+    params[:controller] == "users" && params[:action] == "edit"
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     user = User.find(params[:user_id])
     if user&.verify(params[:verification])
       session[:user_id] = user.id
-      redirect_to reminders_path
+      login_redirect
     else
       flash[:alert] = "Something went wrong"
       redirect_to sign_in_path
@@ -28,6 +28,14 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def login_redirect
+    if current_user.timezone.present?
+      redirect_to reminders_path
+    else
+      redirect_to edit_profile_path
+    end
+  end
 
   def user_params
     params.permit(:phone_number)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,18 @@
+class UsersController < ApplicationController
+  def edit
+  end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to reminders_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:timezone, :phone_number)
+  end
+end

--- a/app/views/reminders/index.html.erb
+++ b/app/views/reminders/index.html.erb
@@ -4,6 +4,7 @@
     <%= link_to "Create New Reminder", new_reminder_path, data: { turbo_frame: dom_id(Reminder.new) }, class: "button" %>
   </section>
   <hr />
+  <p>All reminders will be scheduled in <%= current_user.timezone %>. If this is incorrect, change that on the <%= link_to "edit profile", edit_profile_path, data: { turbo: false }  %> page.</p>
 <% end %>
 
 <%= turbo_frame_tag Reminder.new %>

--- a/app/views/reminders/new.html.erb
+++ b/app/views/reminders/new.html.erb
@@ -9,7 +9,7 @@
       </div>
       <div class="six columns">
         <%= f.label :run_at %>
-        <%= f.datetime_select :run_at, ampm: true, default: 3.days.from_now.in_time_zone("America/Denver") %>
+        <%= f.datetime_select :run_at, ampm: true, default: 3.days.from_now.in_time_zone(current_user.timezone) %>
       </div>
       <div>
         <%= f.submit %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,8 +1,15 @@
 <div class="container">
   <nav class="navbar">
     <h1>TEXT REMINDERS</h1>
-    <% if current_user %>
-      <%= link_to "Sign out", sign_out_path, class: "button" %>
-    <% end %>
+    <div>
+      <% if edit_profile_page? %>
+        <%= link_to "Reminders", reminders_path, class: "button" %>
+      <% else %>
+        <%= link_to "Edit Profile", edit_profile_path, class: "button" %>
+      <% end %>
+      <% if current_user %>
+        <%= link_to "Sign out", sign_out_path, class: "button" %>
+      <% end %>
+    </div>
   </nav>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,10 @@
+<h2>Edit Profile</h2>
+<%= form_with model: current_user, url: update_user_path do |f| %>
+  <%= f.label :phone_number %>
+  <%= f.text_field :phone_number, disabled: true %>
+  <%= f.label :timezone %>
+  <%= f.select :timezone, User::TIMEZONES, { include_blank: "Select Timezone" }, required: true %>
+  <div>
+    <%= f.submit "Save Profile" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,13 @@ Rails.application.routes.draw do
   root to: "reminders#index"
 
   resources :reminders, only: [:index, :new, :create]
+
   get '/sign-in', to: 'sessions#new', as: 'sign_in'
   post '/sign-in', to: 'sessions#create'
   get '/sign-out', to: 'sessions#destroy', as: 'sign_out'
   get '/confirm/:uuid', to: 'sessions#confirm', as: 'confirm'
   post '/verification', to: 'sessions#verification', as: 'session_verification'
+
+  get  '/edit-profile', to: 'users#edit', as: 'edit_profile'
+  patch '/users', to: 'users#update', as: 'update_user'
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:phone_number) { |n| n.to_s.rjust(10, '0') }
     verification { "0847" }
     verification_expiration { 15.minutes.from_now }
+    timezone { nil }
   end
 end

--- a/spec/system/session/user_can_sign_in_spec.rb
+++ b/spec/system/session/user_can_sign_in_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Visitor can sign up", type: :system do
-  let!(:user) { create(:user) }
+  let!(:user) { create(:user, timezone: "Hawaii") }
 
   before do
     allow_any_instance_of(User).to receive(:verify).with("1234").and_return true

--- a/spec/system/session/user_sent_edit_profile_on_login_spec.rb
+++ b/spec/system/session/user_sent_edit_profile_on_login_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "User is redirected to edit profile on sign in", type: :system do
+  let(:user) { create(:user, timezone: nil) }
+
+  it "redirects to edit_profile when user does not have strike zone" do
+    user.generate_verification_code
+
+    visit confirm_path(user.id)
+    fill_in "Verification Code", with: user.verification
+    click_button "Verify"
+
+    expect(current_path).to eq(edit_profile_path)
+  end
+end

--- a/spec/system/visitor_can_sign_up_spec.rb
+++ b/spec/system/visitor_can_sign_up_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe "Visitor can sign up", type: :system do
     fill_in "Verification Code", with: "1234"
     click_button "Verify"
 
-    expect(current_path).to eq(reminders_path)
+    expect(current_path).to eq(edit_profile_path)
   end
 end


### PR DESCRIPTION
This will add an edit-profile page to update a user's timezone. It will redirect to the edit-profile page on log in if the user's timezone is not set.

The edit-profile page has a disabled text field to update a phone number because functionality is needed to verify a code in the event the user changes their phone number.

Closes #24 
