### PR TITLE
HOTFIX: fix appending table for new reminders

### DIFF
--- a/app/jobs/text_verification_sender_job.rb
+++ b/app/jobs/text_verification_sender_job.rb
@@ -3,7 +3,7 @@ class TextVerificationSenderJob < ApplicationJob
 
   def perform(uuid)
     user = User.find_by_id(uuid)
-    return unless user || !reminders_disabled?
+    return unless user && !reminders_disabled?
 
     client.messages.create(
       to: "+1#{user.phone_number}",

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -4,4 +4,5 @@ class Reminder < ApplicationRecord
   belongs_to :user
 
   delegate :phone_number, to: :user, prefix: true
+  delegate :timezone, to: :user, prefix: true
 end

--- a/app/views/reminders/_reminder.html.erb
+++ b/app/views/reminders/_reminder.html.erb
@@ -1,5 +1,5 @@
-<tr>
+<%= content_tag :tr, id: dom_id(reminder) do %>
   <td><%= reminder.text %></td>
-  <td><%= reminder.run_at.in_time_zone("America/Denver") %></td>
+  <td><%= reminder.run_at.in_time_zone(reminder.user_timezone) %></td>
   <td><%= link_to "Edit" %> | <%= link_to "Delete" %></td>
-</tr>
+<% end %>

--- a/app/views/reminders/create.turbo_stream.erb
+++ b/app/views/reminders/create.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.prepend "reminders", partial: "reminders/reminder", locals: { reminder: @reminder } %>
+<%= turbo_stream.append "reminders", @reminder %>
 <%= turbo_stream.update Reminder.new, "" %>

--- a/app/views/reminders/index.html.erb
+++ b/app/views/reminders/index.html.erb
@@ -9,25 +9,23 @@
 
 <%= turbo_frame_tag Reminder.new %>
 
-<%= turbo_frame_tag "reminders" do %>
-  <table class="u-full-width">
-    <thead>
+<table class="u-full-width">
+  <thead>
+    <tr>
+      <th>Text</th>
+      <th>Run at</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody id="reminders">
+    <% if @reminders.any? %>
+      <%= render @reminders %>
+    <% else %>
       <tr>
-        <th>Text</th>
-        <th>Run at</th>
-        <th>Actions</th>
+        <td colspan="3">
+          You have no reminders yet...
+        </td>
       </tr>
-    </thead>
-    <tbody>
-      <% if @reminders.any? %>
-        <%= render @reminders %>
-      <% else %>
-        <tr>
-          <td colspan="3">
-            You have no reminders yet...
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
+    <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
There is a known bug hotwire because you cannot put a turbo_frame_tag
inside a table element because in HTML, table elements only acccept
normal table elements (tr, tbody, thead, th, td) as children.

Closes #21
